### PR TITLE
Fix for SavingsGoalRow Not Updating When Updating Amount Saved

### DIFF
--- a/CentSage/Views/SavingsGoalViews/SavingsGoalRow.swift
+++ b/CentSage/Views/SavingsGoalViews/SavingsGoalRow.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SavingsGoalRow: View {
-  var goal: SavingsGoal
+  @Binding var goal: SavingsGoal
   
   var progress: Double {
     let rawProgress = goal.currentAmount / goal.targetAmount
@@ -49,8 +49,8 @@ struct SavingsGoalRow: View {
   }
 }
 
-#Preview {
-  SavingsGoalRow(goal: PersistenceController.preview.createSampleSavingsGoal())
-    .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
-}
+//#Preview {
+//  SavingsGoalRow(goal: PersistenceController.preview.createSampleSavingsGoal())
+//    .environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+//}
 

--- a/CentSage/Views/SavingsGoalViews/SavingsGoalsListView.swift
+++ b/CentSage/Views/SavingsGoalViews/SavingsGoalsListView.swift
@@ -48,7 +48,7 @@ struct SavingsGoalsListView: View {
               Button(action: {
                 selectedGoal = goal
               }) {
-                SavingsGoalRow(goal: goal)
+                  SavingsGoalRow(goal: $viewModel.goals[viewModel.goals.firstIndex(of: goal)!])
                   .padding()
               }
               .buttonStyle(PlainButtonStyle())


### PR DESCRIPTION
These changes fix a problem where the SavingsGoalRow in SavingsGoalListView would not update when the user updates their goal. This was due to the superview not having read and write access to the subview.

# What it Does
* Fixed by using @ Binding property wrapper in SavingsGoalRow and then passing a binding to a goal object into SavingsGoalRow from SavingsGoalListView.
* Commented out the # Preview macro because they don't play nice with Bindings.

# Screenshot
<img width="580" alt="Screenshot 2023-10-03 at 6 03 39 PM" src="https://github.com/cendress/CentSage/assets/111900227/96d3de79-2d5f-4599-ad39-6bf5d42d0b65">

<img width="758" alt="Screenshot 2023-10-03 at 6 03 52 PM" src="https://github.com/cendress/CentSage/assets/111900227/3e73e4a4-e664-4128-ab2d-8c624f635b21">

